### PR TITLE
Add support to Spanish AM/PM format (p. m./a. m.) in message parsing

### DIFF
--- a/chat_export/chat_export.py
+++ b/chat_export/chat_export.py
@@ -391,11 +391,13 @@ class MessageParser:
         # Chat patterns for different platforms
         self.chat_patterns = {
             'ios': re.compile(r'\[(\d{1,4}.\d{1,2}.\d{2,4}, \d{1,2}:\d{2}(?::\d{2})?(?:\s*[AaPp][Mm])?)\] (.*?): (.*)'),
-            'android': re.compile(r'(\d{1,4}.\d{1,2}.\d{2,4},? \d{1,2}:\d{2}(?::\d{2})?(?:\s*[AaPp][Mm])?) - (.*?): (.*)')
+            'android': re.compile(
+                r'(\d{1,4}.\d{1,2}.\d{2,4},? \d{1,2}:\d{2}(?::\d{2})?(?:\s*[AaPp]\.?\s*[Mm]\.?)?) - (.*?): (.*)')
         }
         self.whatsapp_patterns = {
             'ios': re.compile(r'\[(\d{1,4}.\d{1,2}.\d{2,4}, \d{1,2}:\d{2}(?::\d{2})?(?:\s*[AaPp][Mm])?)\] (.*)'),
-            'android': re.compile(r'(\d{1,4}.\d{1,2}.\d{2,4},? \d{1,2}:\d{2}(?::\d{2})?(?:\s*[AaPp][Mm])?) - (.*)')
+            'android': re.compile(
+                r'(\d{1,4}.\d{1,2}.\d{2,4},? \d{1,2}:\d{2}(?::\d{2})?(?:\s*[AaPp]\.?\s*[Mm]\.?)?) - (.*)')
         }
 
         self.attachment_pattern_android = r'(.+?\.[a-zA-Z0-9]{0,4}) \(.{1,20} .{1,20}\)'


### PR DESCRIPTION
## Problem
The Android message pattern doesn't capture messages with Spanish-style AM/PM format (e.g., "p. m." with spaces and dots).

## Solution
Updated the regex pattern to support:
- Standard English: `PM`, `pm`
- English with dots: `P.M.`, `p.m.`
- Spanish with spaces: `p. m.`, `a. m.`

## Example
Now correctly parses: `4/9/21, 1:10 p. m. - First_name Last_name`